### PR TITLE
Update instructions to install vcpkg on Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ You can build and install libheif using the [vcpkg](https://github.com/Microsoft
 ```
 git clone https://github.com/Microsoft/vcpkg.git
 cd vcpkg
-./bootstrap-vcpkg.sh
+./bootstrap-vcpkg.bat
 ./vcpkg integrate install
 ./vcpkg install libheif
 ```


### PR DESCRIPTION
Source: https://github.com/Microsoft/vcpkg/#quick-start-windows

DO NOT CREATE A PULL REQUEST FOR THIS REPOSITORY, THIS IS ONLY A COPY OF AN EXTERNAL REPOSITORY.

THE ORGINAL REPOSITORY CAN BE FOUND HERE: https://github.com/strukturag/libheif.